### PR TITLE
Moved minibroker tooling into this repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@ minibroker will work with SCF.
 
 ## How to use the tooling
 
-The main entry point / script is `../bin/assess-minibroker-charts.rb`.
+The main entry point / script is `assessor/bin/assess-minibroker-charts.rb`.
 
-Note how this script is not in this subdirectory of `tooling/`, but in
-the main tooling `bin/` directory.
-
-The script and its helpers require:
+The script requires:
 
   - A working `kubectl` command in the `PATH`, with its config
     pointing to
@@ -21,6 +18,14 @@ The script and its helpers require:
   - A working `patch` command in the `PATH`. For a vagrant box this
     means that is is necessary to run `sudo zypper install patch`
     before attempting an assessment.
+  - A working `ruby`, of course, and the gems
+      - fileutils
+      - net/http
+      - open3
+      - optparse
+      - uri
+      - yaml
+  - Furthermore `tar`, and `gzip`.      
 
 Run the the script using
 
@@ -37,6 +42,7 @@ the default configuration, i.e.
 |Admin password	|(Vagrant standard)	|-p, --password		|
 |Mode		|Full run		|-i, --incremental	|
 |Work directory	|(Git root)/`_work/mb-chart-assessment`	|-w, --work-dir		|
+|SCF source dir	|(No default, must be set)		|-s, --scf-dir		|
 
 The mode of `full run` means that all found charts are tested,
 regardless of any previous results. Such a run takes about 2 days at
@@ -67,12 +73,13 @@ at just shy of two days for a full assessment all engines.
 
 The entrypoint is
 
-  - ../bin/assess-minibroker-charts.rb
+  - `assessor/bin/assess-minibroker-charts.rb`
 
 Beyond the above we have a number of engine-dependent patch files in
 the
 
-  - `patches/`
+  - `assessor/patches/`
 
 directory which fix issues in the charts when used with minibroker.
-Without these patches no chart will work.
+Without these patches no chart will work due to file permissions
+issues with `hostpath` volumes used in the vagrant box.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
-# scf-minibroker
-Minibroker tooling to work with SUSE Cloud Foundry
+# Assessing the minibroker database charts.
+
+The main purpose of the tooling in this directory is to assess which
+of the publicly available charts for the databases supported by
+minibroker will work with SCF.
+
+## How to use the tooling
+
+The main entry point / script is `../bin/assess-minibroker-charts.rb`.
+
+Note how this script is not in this subdirectory of `tooling/`, but in
+the main tooling `bin/` directory.
+
+The script and its helpers require:
+
+  - A working `kubectl` command in the `PATH`, with its config
+    pointing to
+  - A working SCF+UAA cluster
+  - A working `cf` client command in the `PATH`. The tooling will
+    target it to the CAP cluster.
+  - A working `patch` command in the `PATH`. For a vagrant box this
+    means that is is necessary to run `sudo zypper install patch`
+    before attempting an assessment.
+
+Run the the script using
+
+```
+    /path/to/assess-minibroker-charts.rb --help
+```
+
+to get help about its options. Without `--help` the script runs with
+the default configuration, i.e.
+
+|Setting	|Value			|Option			|
+|---		|---			|---			|
+|CF namespace	|`cf`			|-n, --namespace	|
+|Admin password	|(Vagrant standard)	|-p, --password		|
+|Mode		|Full run		|-i, --incremental	|
+|Work directory	|(Git root)/`_work/mb-chart-assessment`	|-w, --work-dir		|
+
+The mode of `full run` means that all found charts are tested,
+regardless of any previous results. Such a run takes about 2 days at
+the moment.
+
+An incremental run should be much faster. It is activated with option
+`-i`. In this mode the script ignores all charts for which it has
+results, indicating that they have been processed already.
+
+This enables easy resumption of operation if the script was aborted,
+be it a bug, or the user.
+
+This also enables effective use from within a CI system, checking for
+and processing only new charts as they are added to the stable.
+
+All transient files and directories used by the script will be placed
+into the work directory. The same is true for results.
+
+During operation the script will print progress information to its
+standard output.
+
+Note that the testing of a single chart can take up to 10 minutes,
+although the average looks to be about 4 to 5 minutes. With about 140
+charts to test per engine on average, and four engines we are looking
+at just shy of two days for a full assessment all engines.
+
+## Tool internals, for the maintainer.
+
+The entrypoint is
+
+  - ../bin/assess-minibroker-charts.rb
+
+Beyond the above we have a number of engine-dependent patch files in
+the
+
+  - `patches/`
+
+directory which fix issues in the charts when used with minibroker.
+Without these patches no chart will work.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Assessing the minibroker database charts.
 
-The main purpose of the tooling in this directory is to assess which
+The main purpose of the tooling in this repository is to assess which
 of the publicly available charts for the databases supported by
 minibroker will work with SCF.
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,7 @@ The script requires:
   - A working `patch` command in the `PATH`. For a vagrant box this
     means that is is necessary to run `sudo zypper install patch`
     before attempting an assessment.
-  - A working `ruby`, of course, and the gems
-      - fileutils
-      - net/http
-      - open3
-      - optparse
-      - uri
-      - yaml
+  - A working `ruby`
   - Furthermore `tar`, and `gzip`.      
 
 Run the the script using

--- a/assessor/bin/assess-minibroker-charts.rb
+++ b/assessor/bin/assess-minibroker-charts.rb
@@ -1,0 +1,628 @@
+#!/usr/bin/env ruby
+##
+# The purpose of this script is to assess which of the publicly
+# available charts for the databases supported by minibroker will work
+# with SCF.
+
+# Configuration
+# - Fixed location: `stable` helm repository
+# - Configurable:   work directory for state
+# - Configurable:   scf source directory
+# - Configurable:   SCF namespace
+# - Configurable:   Cluster Admin Password
+# - Configurable:   Operation mode (full, incremental)
+
+require 'fileutils'
+require 'net/http'
+require 'open3'
+require 'optparse'
+require 'uri'
+require 'yaml'
+
+# Global option for error handling in run, capture
+$opts = { errexit: true }
+
+@top = File.dirname(File.dirname(File.dirname(File.absolute_path(__FILE__))))
+
+def main
+  config
+  base_statistics
+
+  @assessed = 0
+  @skipped = 0
+  state
+
+  engines.each do |engine|
+    master_index[engine].each do |chart|
+      enginev       = chart['appVersion']
+      chartv        = chart['version']
+      chartlocation = chart['urls'].first
+
+      # We are ignoring all the entries for which we do not have the
+      # engine version. Because that is the plan id later, therefore
+      # required.
+      next unless enginev
+
+      next if skip_chart(engine, enginev, chartv)
+      assess_chart(chart, engine, enginev, chartv, chartlocation)
+      @assessed += 1
+    end
+  end
+
+  rewind
+  if @skipped
+    puts "#{"Skipped".cyan}:  #{@skipped}"
+  end
+  if @assessed
+    puts "#{"Assessed".cyan}: #{@assessed}"
+  end
+end
+
+def config
+  @workdir     = File.join(@top, '_work/assessor')
+  @namespace   = "cf"
+  @auth        = "changeme"
+  @incremental = false
+  @scfdir      = nil
+
+  OptionParser.new do |opts|
+    opts.banner = "Usage: assess-minibroker-charts [options]"
+    opts.on("-wPATH", "--work-dir=PATH", "Set work directory for state and transients") do |v|
+      @workdir = File.absolute_path(v.to_s)
+    end
+    opts.on("-sPATH", "--scf-dir=PATH", "Set SCF source directory") do |v|
+      @scfdir = File.absolute_path(v.to_s)
+    end
+    opts.on("-nNAME", "--namespace=NAME", "Set SCF namespace") do |v|
+      @namespace = v.to_s
+    end
+    opts.on("-pPASS", "--password=PASS", "Set cluster admin password") do |v|
+      @auth = v.to_s
+    end
+    opts.on("-i", "--incremental", "Activate incremental mode") do |v|
+      @incremental = true
+    end
+  end.parse!
+
+  puts "Configuration".cyan
+  puts "  - Namespace: #{@namespace.blue}"
+  puts "  - Password:  #{@auth.blue}"
+  puts "  - Mode:      #{mode.blue}"
+  puts "  - Top:       #{@top.blue}"
+  puts "  - Work dir:  #{@workdir.blue}"
+  puts "  - SCF dir:   #{@scfdir.blue}"
+end
+
+def mode
+  if @incremental
+    "incremental, keeping previous data"
+  else
+    "fresh, clearing previous data"
+  end
+end
+
+def engines
+  # Add new engines here. May also have to change the test case
+  # selection if the name of the test case in the brain tests deviates
+  # from the name of the database engine. We assume a name of the form
+  # `<nnn>_minibroker_<engine>_test`.
+  [
+    'mariadb',
+    'mongodb',
+    'postgresql',
+    'redis'
+  ]
+end
+
+def master_index
+  unless @master
+    puts "#{"Retrieving".cyan} master index ..."
+    @master = helm_index(stable)['entries']
+  end
+  @master
+end
+
+def helm_index(location)
+    uri = URI.parse (location + "/index.yaml")
+    res = Net::HTTP.get_response uri
+
+    # Debugging, save index data.
+    File.write(File.join(@workdir, 'index-location.txt'), uri)
+    File.write(File.join(@workdir, 'index.yaml'), res.body)
+
+    YAML.load (res.body)
+end
+
+def base_statistics
+  engines.each do |engine|
+    # Debugging. Save per-engine indices.
+    File.write(File.join(@workdir, "e-#{engine}.yaml"), master_index[engine].to_yaml)
+
+    # We are ignoring all the entries for which we do not have the
+    # engine version. Because that is the plan id later, therefore
+    # required.
+    puts "#{"Extracting".cyan} engine #{engine.blue}: #{master_index[engine].select do |chart|
+         chart ['appVersion']
+    end.length.to_s.cyan}"
+  end
+end
+
+def state
+  # Memoized
+  unless @state
+    # Look for state only in incremental mode. Do not fail if missing,
+    # just fall back to regular mode, starting with empty state.
+    if @incremental && File.exists?(statepath)
+      @state = YAML.load_file(statepath)
+    else
+      @state = {}
+    end
+    # State schema:
+    # <engine>.<version>.works	:: boolean
+    # <engine>.<version>.app	:: string
+    #
+    # version is chart version  (`version`)
+    # app     is engine version (`appVersion`)
+  end
+  @state
+end
+
+def state_save(engine, enginev, chartv, success)
+  @state[engine] = {} unless @state[engine]
+  @state[engine][chartv] = {
+    'app'   => enginev,
+    'works' => success,
+  }
+  File.write(statepath, @state.to_yaml)
+end
+
+def skip_chart(engine, enginev, chartv)
+  if @incremental && state[engine] && state[engine][chartv]
+    @skipped += 1
+    rewind
+    write "Skipping #{engine} #{enginev} #{chartv}"
+    # delay to actually see the output ?
+    true
+  else
+    false
+  end
+end
+
+def assess_chart (chart, engine, enginev, chartv, chartlocation)
+  log_start(engine, enginev, chartv)
+
+  rewind
+  write "  - #{engine.blue} #{enginev.blue}, chart #{chartv.blue} ..."
+
+  separator " helm repo setup ..." do
+    @the_repo = helm_repo_setup(chart, engine, chartlocation)
+
+    if @the_repo
+      " helm repo #{"up".green},"
+    else
+      state_save(engine, enginev, chartv, false)
+      " helm repo #{"start failed".repo}, likely a patch failure"
+    end
+  end
+
+  if @the_repo
+    separator " testing ..." do
+      success = do_test(@the_repo, engine)
+
+      state_save(engine, enginev, chartv, success)
+      if success
+        archive_save(engine, chartv)
+        regenerate_working_index
+        " testing #{"OK".green},"
+      else
+        " testing #{"FAIL".red},"
+      end
+    end
+
+    # clear leftovers, service & broker parts, ignoring errors.
+    separator " post assessment, clearing service & broker state ..." do
+      set errexit: false do
+        run "cf marketplace"
+        stdout, _, _ = capture "cf service-brokers"
+        matches = stdout.match(/(minibroker-[^ 	]*)/)
+        if matches
+          broker = matches[1]
+          run "cf", "purge-service-offering", "-f", engine
+          run "cf", "delete-service-broker",  "-f", broker
+        end
+      end
+      ""
+    end
+
+    separator " helm repo shutdown ..." do
+      helm_repo_shutdown
+      " helm repo #{"down".blue},"
+    end
+  end
+
+  puts " done"
+  log_done
+end
+
+def helm_repo_shutdown
+  # After a test we shut the local helm repository down again. We ignore failures.
+  set errexit: false do
+    run "cf", "delete",       "-f", helm_app
+    run "cf", "delete-space", "-f", "mb-charting"
+    run "cf", "delete-org",   "-f", "mb-charting"
+  end
+  FileUtils.remove_dir(appdir, force = true)
+end
+
+def helm_repo_setup(chart, engine, chartlocation)
+  # Assemble and run node-env app serving the helm repository.
+  # I. Copy original app into fresh directory
+  FileUtils.remove_dir(appdir, force = true)
+  FileUtils.cp_r(appsrc, appdir)
+
+  # II. Change app name to something more suitable
+  m = YAML.load_file (manifest)
+  m['applications'][0]['name'] = helm_app
+  File.write(manifest, m.to_yaml)
+
+  # III. Write remote helm chart to local file
+  get_engine_chart(chartlocation)
+
+  # IV. Patch local chart archive. Stop on failure
+  return "" unless sucessfully_patched_chart(engine)
+
+  # V. Place index (*) and patched chart.
+  #    (*) With proper chart archive reference
+  File.write(chart_index, make_index_yaml(chart, engine, chart_ref))
+  FileUtils.cp(archive_patched, archive_app)
+
+  # VI. Start repository (push app)
+
+  run "cf", "api", "--skip-ssl-validation", target
+  run "cf", "auth", "admin", @auth
+  run "cf create-org   mb-charting"
+  run "cf target    -o mb-charting"
+  run "cf create-space mb-charting"
+  run "cf target    -o mb-charting"
+  run "cf enable-feature-flag diego_docker"
+
+  FileUtils.cd(appdir) do
+    run "cf", "push", "-n", helm_app
+  end
+
+  # Report location
+  helm_repo
+end
+
+def get_engine_chart(chartlocation)
+    uri = URI.parse (chartlocation)
+    res = Net::HTTP.get_response uri
+    File.write(archive_orig, res.body)
+end
+
+def sucessfully_patched_chart(engine)
+  patch = patch_of(engine)
+  if File.exists?(patch)
+    # Patch required - setup, unpack, modify, repack, cleanup
+    # setup
+    tmp = File.join(@workdir, "tmp")
+    FileUtils.remove_dir(tmp, force = true)
+    FileUtils.mkdir_p(tmp)
+
+    # unpack
+    run "tar", "xfz", archive_orig, "-C", tmp
+
+    # modify
+    FileUtils.cd (File.join(tmp, engine, "templates")) do
+      @patch_stdout, _, @patch_status = capture "patch", "--verbose", "-i", patch
+    end
+    unless @patch_status.success?
+      # Check for `Reversed` and accept that, else fail
+      unless @patch_stdout =~ /Reversed/
+        return false
+      end
+    end
+
+    # repack
+    run "tar", "cfz", archive_patched, "-C", tmp, engine
+
+    # cleanup
+    FileUtils.remove_dir(tmp)
+  else
+    # No patch, just copy, cannot fail
+    FileUtils.cp(archive_orig, archive_patched)
+  end
+  true
+end
+
+def make_index_yaml (chart, engine, newloc)
+  index = {
+    'apiVersion' => 'v1',
+    'entries'    => {
+      engine => []
+    },
+  }
+  index['entries'][engine] << chart.dup
+  # Relocate
+  index['entries'][engine][0]['urls'] = [ newloc ]
+  # Go does not parse the timestamp format emitted by ruby.
+  # See if using a string is ok.
+  index['entries'][engine][0]['created'] = fixed_time
+  index.to_yaml
+end
+
+def do_test(the_repo, engine)
+  _, _, status = capture tester, "acceptance-tests-brain",
+	                 "env.INCLUDE=#{testcase_of(engine)}",
+	                 "env.KUBERNETES_REPO=#{the_repo}",
+	                 "env.VERBOSE=true"
+  status.success?
+end
+
+# ......................................................................
+# Engine-specific constructed values
+
+def testcase_of(engine)
+  return "_minibroker_postgres" if engine =~ /postgresql/
+  "_minibroker_#{engine}"
+end
+
+def patch_of(engine)
+  File.join(@top, "assessor/patches", "#{engine}.patch")
+end
+
+def archive_save(engine, chartv)
+  dst = File.join(archive_saved, "#{engine}-#{chartv}.tgz")
+  FileUtils.mkdir_p(archive_saved)
+  FileUtils.cp(archive_patched, dst)
+end
+
+def regenerate_working_index
+  # Extract the chart blocks for all working charts from the master,
+  # patch the archive location to refer to the internal dev helm
+  # repository used by the brain tests, and save to a file.
+  working = {}
+  engines.each do |engine|
+    working[engine] = []
+    master_index[engine].each do |chart|
+      chartv = chart['version']
+      next unless @state && @state[engine] && @state[engine][chartv] && @state[engine][chartv]['works']
+      new = chart.dup
+      new['created'] = fixed_time
+      new['urls'] = "#{mbbt_repository}/#{engine}-#{chartv}.tgz"
+      working[engine] << new
+    end
+  end
+  File.write(working_saved, working.to_yaml)
+end
+
+# ......................................................................
+# Various (semi)constant values, mostly paths and the like
+
+def mbbt_repository
+  "https://minibroker-helm-charts.s3.amazonaws.com/kubernetes-charts"
+end
+
+def fixed_time
+  "2018-07-30T17:55:01.330815339Z"
+end
+
+def stable
+  "https://kubernetes-charts.storage.googleapis.com"
+end
+
+def helm_app
+  "chart-under-test"
+end
+
+def chart_in_app
+  "chart.tgz"
+end
+
+def statepath
+  @statepath = File.join(@workdir, 'results.yaml') unless @statepath
+  @statepath
+end
+
+def appdir
+  @appdir = File.join(@workdir, "charts") unless @appdir
+  @appdir
+end
+
+def working_saved
+  @wsaved = File.join(archive_saved, 'index.yaml') unless @wsaved
+  @wsaved
+end
+
+def archive_saved
+  @asaved = File.join(@workdir, 'ok') unless @asaved
+  @asaved
+end
+
+def archive_orig
+  @aunpatched = File.join(@workdir, 'archive-orig.tgz') unless @aunpatched
+  @aunpatched
+end
+
+def archive_patched
+  @apatched = File.join(@workdir, 'archive-patched.tgz') unless @apatched
+  @apatched
+end
+
+def manifest
+  @manifest = File.join(appdir, "manifest.yml") unless @manifest
+  @manifest
+end
+
+def chart_index
+  @chartindex = File.join(appdir, "index.yaml") unless @chartindex
+  @chartindex
+end
+
+def archive_app
+  @aapp = File.join(appdir, chart_in_app) unless @aapp
+  @aapp
+end
+
+def domain
+  @domain, _, _ = capture "kubectl get pods -o json --namespace \"#{@namespace}\" api-group-0 | jq -r '.spec.containers[0].env[] | select(.name == \"DOMAIN\").value'" unless @domain
+  @domain
+end
+
+def tester
+  @brain = File.join(@scfdir, "make/tests") unless @brain
+  @brain
+end
+
+def appsrc
+  @appsrc = File.join(@top, "src/scf-release/src/acceptance-tests-brain/test-resources/node-env") unless @appsrc
+  @appsrc
+end
+
+def helm_repo
+  @helmrepo = "http://#{helm_app}.#{domain}" unless @helmrepo
+  @helmrepo
+end
+
+def target
+  @target = "https://api.#{domain}" unless @target
+  @target
+end
+
+def chart_ref
+  @chartref = "#{helm_repo}/#{chart_in_app}" unless @chartref
+  @chartref
+end
+
+# ......................................................................
+# Logging, and terminal cursor control
+# First three commands snarfed from test utils and modified to suit
+# (divert output into log file)
+
+# Set global options.
+# If a block is given, the options are only active in that block.
+def set(opts={})
+    if block_given?
+        old_opts = $opts.dup
+        $opts.merge! opts
+        yield
+        $opts.merge! old_opts
+    else
+        $opts.merge! opts
+    end
+end
+
+def run(*args)
+  opts = $opts.dup
+  opts.merge! args.last if args.last.is_a? Hash
+  _, _, status = capture(*args)
+  return unless opts[:errexit]
+  unless status.success?
+    # Print an error at the failure site
+    puts "Command exited with #{status.exitstatus}".red
+    fail "Command exited with #{status.exitstatus}"
+  end
+end
+
+def capture(*args)
+  _print_command(*args)
+  args.last.delete :errexit if args.last.is_a? Hash
+  stdout, stderr, status = Open3.capture3(*args)
+  log stdout
+  log stderr.red
+  return stdout.chomp, stderr.chomp, status
+end
+
+# Internal helper: print a command line in the log.
+def _print_command(*args)
+    cmd = args.dup
+    cmd.shift if cmd.first.is_a? Hash
+    cmd.pop if cmd.last.is_a? Hash
+    log "+ #{cmd.join(" ")}".bold
+    log "\n"
+end
+
+def separator(text)
+  sepline = "____________________________________________________________ #{text} ___"
+  log "\n#{sepline.magenta}\n"
+  write text
+  message = yield
+  left text.length
+  eeol
+  write message
+end
+
+def log_start(engine,enginev,chartv)
+  enginedir = File.join(@workdir, engine)
+  @log = File.join(enginedir, "#{enginev}-#{chartv}.log")
+  FileUtils.mkdir_p(enginedir)
+  FileUtils.rm_f(@log)
+  FileUtils.touch(@log)
+end
+
+def log(text)
+  # append to log file @log
+  # https://stackoverflow.com/questions/27956638/how-to-append-a-text-to-file-succinctly/27956730
+  #File.write(@log, text, File.size(@log), mode: 'a')
+  File.write(@log, text, mode: 'a')
+end
+
+def log_done
+  @log = nil
+end
+
+def write (text)
+  print text
+  $stdout.flush
+end
+
+# Move cursor n character towards the beginning of the line
+def left(n=1)
+  print "\033[#{n}D"
+end
+
+# Erase (from cursor to) End Of Line
+def eeol
+  print "\033[K"
+end
+
+# Move to beginning of line and erase
+def rewind
+  print "\r"
+  eeol
+end
+
+# ......................................................................
+# Colorization support.
+class String
+  def red
+    "\033[0;31m#{self}\033[0m"
+  end
+
+  def green
+    "\033[0;32m#{self}\033[0m"
+  end
+
+  def yellow
+    "\033[0;33m#{self}\033[0m"
+  end
+
+  def blue
+    "\033[0;34m#{self}\033[0m"
+  end
+
+  def magenta
+    "\033[0;35m#{self}\033[0m"
+  end
+
+  def cyan
+    "\033[0;36m#{self}\033[0m"
+  end
+
+  def bold
+    "\033[0;1m#{self}\033[0m"
+  end
+end
+
+# ......................................................................
+main

--- a/assessor/bin/assess-minibroker-charts.rb
+++ b/assessor/bin/assess-minibroker-charts.rb
@@ -152,7 +152,7 @@ def assess_chart (chart, engine, enginev, chartv, chart_location)
       " helm repo #{"down".blue},"
     end
 
-    puts " done"
+    puts " done = #{@logfile.cyan}"
     log_done
   end
 end

--- a/assessor/bin/assess-minibroker-charts.rb
+++ b/assessor/bin/assess-minibroker-charts.rb
@@ -37,7 +37,6 @@ def main
 
   @assessed = 0
   @skipped = 0
-  state
 
   engines.each do |engine|
     master_index[engine].each do |chart|

--- a/assessor/bin/assess-minibroker-charts.rb
+++ b/assessor/bin/assess-minibroker-charts.rb
@@ -19,8 +19,15 @@ require 'optparse'
 require 'uri'
 require 'yaml'
 
-# Global option for error handling in run, capture
-$opts = { errexit: true }
+require_relative "../lib/colors.rb"
+require_relative "../lib/config.rb"
+require_relative "../lib/helmrepo.rb"
+require_relative "../lib/locations.rb"
+require_relative "../lib/log.rb"
+require_relative "../lib/spawn.rb"
+require_relative "../lib/state.rb"
+require_relative "../lib/terminal.rb"
+require_relative "../lib/testcore.rb"
 
 @top = File.dirname(File.dirname(File.dirname(File.absolute_path(__FILE__))))
 
@@ -42,78 +49,15 @@ def main
       # engine version. Because that is the plan id later, therefore
       # required.
       next unless enginev
-
       next if skip_chart(engine, enginev, chartv)
+
       assess_chart(chart, engine, enginev, chartv, chartlocation)
-      @assessed += 1
     end
   end
 
   rewind
-  if @skipped
-    puts "#{"Skipped".cyan}:  #{@skipped}"
-  end
-  if @assessed
-    puts "#{"Assessed".cyan}: #{@assessed}"
-  end
-end
-
-def config
-  @workdir     = File.join(@top, '_work/assessor')
-  @namespace   = "cf"
-  @auth        = "changeme"
-  @incremental = false
-  @scfdir      = nil
-
-  OptionParser.new do |opts|
-    opts.banner = "Usage: assess-minibroker-charts [options]"
-    opts.on("-wPATH", "--work-dir=PATH", "Set work directory for state and transients") do |v|
-      @workdir = File.absolute_path(v.to_s)
-    end
-    opts.on("-sPATH", "--scf-dir=PATH", "Set SCF source directory") do |v|
-      @scfdir = File.absolute_path(v.to_s)
-    end
-    opts.on("-nNAME", "--namespace=NAME", "Set SCF namespace") do |v|
-      @namespace = v.to_s
-    end
-    opts.on("-pPASS", "--password=PASS", "Set cluster admin password") do |v|
-      @auth = v.to_s
-    end
-    opts.on("-i", "--incremental", "Activate incremental mode") do |v|
-      @incremental = true
-    end
-  end.parse!
-
-  puts "Configuration".cyan
-  puts "  - Namespace: #{@namespace.blue}"
-  puts "  - Password:  #{@auth.blue}"
-  puts "  - Mode:      #{mode.blue}"
-  puts "  - Top:       #{@top.blue}"
-  puts "  - Work dir:  #{@workdir.blue}"
-  puts "  - SCF dir:   #{@scfdir.blue}"
-
-  FileUtils.mkdir_p(@workdir)
-end
-
-def mode
-  if @incremental
-    "incremental, keeping previous data"
-  else
-    "fresh, clearing previous data"
-  end
-end
-
-def engines
-  # Add new engines here. May also have to change the test case
-  # selection if the name of the test case in the brain tests deviates
-  # from the name of the database engine. We assume a name of the form
-  # `<nnn>_minibroker_<engine>_test`.
-  [
-    'mariadb',
-    'mongodb',
-    'postgresql',
-    'redis'
-  ]
+  puts "#{"Skipped".cyan}:  #{@skipped}"  if @skipped
+  puts "#{"Assessed".cyan}: #{@assessed}" if @assessed
 end
 
 def master_index
@@ -149,36 +93,6 @@ def base_statistics
   end
 end
 
-def state
-  # Memoized
-  unless @state
-    # Look for state only in incremental mode. Do not fail if missing,
-    # just fall back to regular mode, starting with empty state.
-    if @incremental && File.exists?(statepath)
-      @state = YAML.load_file(statepath)
-    else
-      @state = {}
-    end
-    # Schema:
-    # - state[<engine>][<version>]['works']	:: boolean
-    # - state[<engine>][<version>]['app']	:: string
-    #
-    # version is chart version  (`version`)
-    # app     is engine version (`appVersion`)
-    @state.default_proc = { |h, k| h[k] = Hash.new }
-  end
-  @state
-end
-
-def state_save(engine, enginev, chartv, success)
-  @state[engine] ||= {}
-  @state[engine][chartv] = {
-    'app'   => enginev,
-    'works' => success,
-  }
-  File.write(statepath, @state.to_yaml)
-end
-
 def skip_chart(engine, enginev, chartv)
   return false unless @incremental && state[engine][chartv]
   @skipped += 1
@@ -193,6 +107,8 @@ def assess_chart (chart, engine, enginev, chartv, chartlocation)
 
   rewind
   write "  - #{engine.blue} #{enginev.blue}, chart #{chartv.blue} ..."
+  @success = false
+
   begin
     separator " helm repo setup ..." do
       @the_repo = helm_repo_setup(chart, engine, chartlocation)
@@ -208,12 +124,10 @@ def assess_chart (chart, engine, enginev, chartv, chartlocation)
     return "" unless @the_repo
 
     separator " testing ..." do
-      success = do_test(@the_repo, engine)
+      @success = do_test(@the_repo, engine)
+      state_save(engine, enginev, chartv, @success)
 
-      state_save(engine, enginev, chartv, success)
-      if success
-        archive_save(engine, chartv)
-        regenerate_working_index
+      if @success
         " testing #{"OK".green},"
       else
         " testing #{"FAIL".red},"
@@ -222,20 +136,15 @@ def assess_chart (chart, engine, enginev, chartv, chartlocation)
 
     # clear leftovers, service & broker parts, ignoring errors.
     separator " post assessment, clearing service & broker state ..." do
-      set errexit: false do
-        run "cf marketplace"
-        stdout, _, _ = capture "cf service-brokers"
-        matches = stdout.match(/(minibroker-\S*)/)
-        if matches
-          broker = matches[1]
-          run "cf", "purge-service-offering", "-f", engine
-          run "cf", "delete-service-broker",  "-f", broker
-        end
-      end
+      test_clear(engine)
       ""
     end
 
   ensure
+    @assessed += 1
+    archive_save(engine, chartv) if @success
+    regenerate_working_index if @success
+
     separator " helm repo shutdown ..." do
       helm_repo_shutdown
       " helm repo #{"down".blue},"
@@ -243,368 +152,6 @@ def assess_chart (chart, engine, enginev, chartv, chartlocation)
 
     puts " done"
     log_done
-  end
-end
-
-def helm_repo_shutdown
-  # After a test we shut the local helm repository down again. We ignore failures.
-  set errexit: false do
-    run "cf", "delete",       "-f", helm_app
-    run "cf", "delete-space", "-f", "mb-charting"
-    run "cf", "delete-org",   "-f", "mb-charting"
-  end
-  FileUtils.remove_dir(appdir, force = true)
-end
-
-def helm_repo_setup(chart, engine, chartlocation)
-  # Assemble and run node-env app serving the helm repository.
-  # I. Copy original app into fresh directory
-  FileUtils.remove_dir(appdir, force = true)
-  FileUtils.cp_r(appsrc, appdir)
-
-  # II. Change app name to something more suitable
-  m = YAML.load_file (manifest)
-  m['applications'][0]['name'] = helm_app
-  File.write(manifest, m.to_yaml)
-
-  # III. Write remote helm chart to local file
-  get_engine_chart(chartlocation)
-
-  # IV. Patch local chart archive. Stop on failure
-  return "" unless sucessfully_patched_chart(engine)
-
-  # V. Place index (*) and patched chart.
-  #    (*) With proper chart archive reference
-  File.write(chart_index, make_index_yaml(chart, engine, chart_ref))
-  FileUtils.cp(archive_patched, archive_app)
-
-  # VI. Start repository (push app)
-
-  run "cf", "api", "--skip-ssl-validation", target
-  run "cf", "auth", "admin", @auth
-  run "cf create-org   mb-charting"
-  run "cf target    -o mb-charting"
-  run "cf create-space mb-charting"
-  run "cf target    -o mb-charting"
-  run "cf enable-feature-flag diego_docker"
-
-  FileUtils.cd(appdir) do
-    run "cf", "push", "-n", helm_app
-  end
-
-  # Report location
-  helm_repo
-end
-
-def get_engine_chart(chartlocation)
-    uri = URI.parse (chartlocation)
-    res = Net::HTTP.get_response uri
-    File.write(archive_orig, res.body)
-end
-
-def sucessfully_patched_chart(engine)
-  patch = patch_of(engine)
-  if File.exists?(patch)
-    # Patch required - setup, unpack, modify, repack, cleanup
-    # setup
-    tmp = File.join(@workdir, "tmp")
-    FileUtils.remove_dir(tmp, force = true)
-    FileUtils.mkdir_p(tmp)
-
-    # unpack
-    run "tar", "xfz", archive_orig, "-C", tmp
-
-    # modify
-    FileUtils.cd (File.join(tmp, engine, "templates")) do
-      @patch_stdout, _, @patch_status = capture "patch", "--verbose", "-i", patch
-    end
-    unless @patch_status.success?
-      # Check for `Reversed` and accept that, else fail
-      unless @patch_stdout =~ /Reversed/
-        return false
-      end
-    end
-
-    # repack
-    run "tar", "cfz", archive_patched, "-C", tmp, engine
-
-    # cleanup
-    FileUtils.remove_dir(tmp)
-  else
-    # No patch, just copy, cannot fail
-    FileUtils.cp(archive_orig, archive_patched)
-  end
-  true
-end
-
-def make_index_yaml (chart, engine, newloc)
-  index = {
-    'apiVersion' => 'v1',
-    'entries'    => {
-      engine => []
-    },
-  }
-  index['entries'][engine] << chart.dup
-  # Relocate
-  index['entries'][engine][0]['urls'] = [ newloc ]
-  # Go does not parse the timestamp format emitted by ruby.
-  # See if using a string is ok.
-  index['entries'][engine][0]['created'] = fixed_time
-  index.to_yaml
-end
-
-def do_test(the_repo, engine)
-  _, _, status = capture tester, "acceptance-tests-brain",
-	                 "env.INCLUDE=#{testcase_of(engine)}",
-	                 "env.KUBERNETES_REPO=#{the_repo}",
-	                 "env.VERBOSE=true"
-  status.success?
-end
-
-# ......................................................................
-# Engine-specific constructed values
-
-def testcase_of(engine)
-  return "_minibroker_postgres" if engine =~ /postgresql/
-  "_minibroker_#{engine}"
-end
-
-def patch_of(engine)
-  File.join(@top, "assessor/patches", "#{engine}.patch")
-end
-
-def archive_save(engine, chartv)
-  dst = File.join(archive_saved, "#{engine}-#{chartv}.tgz")
-  FileUtils.mkdir_p(archive_saved)
-  FileUtils.cp(archive_patched, dst)
-end
-
-def regenerate_working_index
-  # Extract the chart blocks for all working charts from the master,
-  # patch the archive location to refer to the internal dev helm
-  # repository used by the brain tests, and save to a file.
-  working = {}
-  engines.each do |engine|
-    working[engine] = []
-    master_index[engine].each do |chart|
-      chartv = chart['version']
-      next unless @state && @state[engine] && @state[engine][chartv] && @state[engine][chartv]['works']
-      new = chart.dup
-      new['created'] = fixed_time
-      new['urls'] = "#{mbbt_repository}/#{engine}-#{chartv}.tgz"
-      working[engine] << new
-    end
-  end
-  File.write(working_saved, working.to_yaml)
-end
-
-# ......................................................................
-# Various (semi)constant values, mostly paths and the like
-
-def mbbt_repository
-  "https://minibroker-helm-charts.s3.amazonaws.com/kubernetes-charts"
-end
-
-def fixed_time
-  "2018-07-30T17:55:01.330815339Z"
-end
-
-def stable
-  "https://kubernetes-charts.storage.googleapis.com"
-end
-
-def helm_app
-  "chart-under-test"
-end
-
-def chart_in_app
-  "chart.tgz"
-end
-
-def statepath
-  @statepath ||= File.join(@workdir, 'results.yaml')
-end
-
-def appdir
-  @appdir ||= File.join(@workdir, "charts")
-end
-
-def working_saved
-  @wsaved ||= File.join(archive_saved, 'index.yaml')
-end
-
-def archive_saved
-  @asaved ||= File.join(@workdir, 'ok')
-end
-
-def archive_orig
-  @aunpatched ||= File.join(@workdir, 'archive-orig.tgz')
-end
-
-def archive_patched
-  @apatched ||= File.join(@workdir, 'archive-patched.tgz')
-end
-
-def manifest
-  @manifest ||= File.join(appdir, "manifest.yml")
-end
-
-def chart_index
-  @chartindex ||= File.join(appdir, "index.yaml")
-end
-
-def archive_app
-  @aapp ||= File.join(appdir, chart_in_app)
-end
-
-def domain
-  @domain, _, _ = capture "kubectl get pods -o json --namespace \"#{@namespace}\" api-group-0 | jq -r '.spec.containers[0].env[] | select(.name == \"DOMAIN\").value'" unless @domain
-  @domain
-end
-
-def tester
-  @brain ||= File.join(@scfdir, "make/tests")
-end
-
-def appsrc
-  @appsrc ||= File.join(@top, "src/scf-release/src/acceptance-tests-brain/test-resources/node-env")
-end
-
-def helm_repo
-  @helmrepo ||= "http://#{helm_app}.#{domain}"
-end
-
-def target
-  @target ||= "https://api.#{domain}"
-end
-
-def chart_ref
-  @chartref ||= "#{helm_repo}/#{chart_in_app}"
-end
-
-# ......................................................................
-# Logging, and terminal cursor control
-# First three commands snarfed from test utils and modified to suit
-# (divert output into log file)
-
-# Set global options.
-# If a block is given, the options are only active in that block.
-def set(opts={})
-    if block_given?
-        old_opts = $opts.dup
-        $opts.merge! opts
-        yield
-        $opts.merge! old_opts
-    else
-        $opts.merge! opts
-    end
-end
-
-def run(*args)
-  opts = $opts.dup
-  opts.merge! args.last if args.last.is_a? Hash
-  _, _, status = capture(*args)
-  return unless opts[:errexit]
-  unless status.success?
-    # Print an error at the failure site
-    puts "Command exited with #{status.exitstatus}".red
-    fail "Command exited with #{status.exitstatus}"
-  end
-end
-
-def capture(*args)
-  _print_command(*args)
-  args.last.delete :errexit if args.last.is_a? Hash
-  stdout, stderr, status = Open3.capture3(*args)
-  log stdout
-  log stderr.red
-  return stdout.chomp, stderr.chomp, status
-end
-
-# Internal helper: print a command line in the log.
-def _print_command(*args)
-    cmd = args.dup
-    cmd.shift if cmd.first.is_a? Hash
-    cmd.pop if cmd.last.is_a? Hash
-    log "+ #{cmd.join(" ")}".bold
-    log "\n"
-end
-
-def separator(text)
-  sepline = '_' * 60 + " #{text} ___"
-  log "\n#{sepline.magenta}\n"
-  write text
-  message = yield
-  left text.length
-  eeol
-  write message
-end
-
-def log_start(engine, enginev, chartv)
-  enginedir = File.join(@workdir, engine)
-  FileUtils.mkdir_p(enginedir)
-  @log = File.open(File.join(enginedir, "#{enginev}-#{chartv}.log"),
-                   File::CREAT|File::TRUNC|File::APPEND)
-end
-
-def log(text)
-  @log.puts text
-end
-
-def log_done
-  @log = nil
-end
-
-def write(text)
-  print text
-  $stdout.flush
-end
-
-# Move cursor n character towards the beginning of the line
-def left(n=1)
-  print "\033[#{n}D"
-end
-
-# Erase (from cursor to) End Of Line
-def eeol
-  print "\033[K"
-end
-
-# Move to beginning of line and erase
-def rewind
-  print "\r"
-  eeol
-end
-
-# ......................................................................
-# Colorization support.
-class String
-  def red
-    "\033[0;31m#{self}\033[0m"
-  end
-
-  def green
-    "\033[0;32m#{self}\033[0m"
-  end
-
-  def yellow
-    "\033[0;33m#{self}\033[0m"
-  end
-
-  def blue
-    "\033[0;34m#{self}\033[0m"
-  end
-
-  def magenta
-    "\033[0;35m#{self}\033[0m"
-  end
-
-  def cyan
-    "\033[0;36m#{self}\033[0m"
-  end
-
-  def bold
-    "\033[0;1m#{self}\033[0m"
   end
 end
 

--- a/assessor/lib/colors.rb
+++ b/assessor/lib/colors.rb
@@ -1,0 +1,32 @@
+
+# ......................................................................
+# Colorization support.
+class String
+  def red
+    "\033[0;31m#{self}\033[0m"
+  end
+
+  def green
+    "\033[0;32m#{self}\033[0m"
+  end
+
+  def yellow
+    "\033[0;33m#{self}\033[0m"
+  end
+
+  def blue
+    "\033[0;34m#{self}\033[0m"
+  end
+
+  def magenta
+    "\033[0;35m#{self}\033[0m"
+  end
+
+  def cyan
+    "\033[0;36m#{self}\033[0m"
+  end
+
+  def bold
+    "\033[0;1m#{self}\033[0m"
+  end
+end

--- a/assessor/lib/config.rb
+++ b/assessor/lib/config.rb
@@ -1,0 +1,59 @@
+
+def config
+  @workdir     = File.join(@top, '_work/assessor')
+  @namespace   = "cf"
+  @auth        = "changeme"
+  @incremental = false
+  @scfdir      = nil
+
+  OptionParser.new do |opts|
+    opts.banner = "Usage: assess-minibroker-charts [options]"
+    opts.on("-wPATH", "--work-dir=PATH", "Set work directory for state and transients") do |v|
+      @workdir = File.absolute_path(v.to_s)
+    end
+    opts.on("-sPATH", "--scf-dir=PATH", "Set SCF source directory") do |v|
+      @scfdir = File.absolute_path(v.to_s)
+    end
+    opts.on("-nNAME", "--namespace=NAME", "Set SCF namespace") do |v|
+      @namespace = v.to_s
+    end
+    opts.on("-pPASS", "--password=PASS", "Set cluster admin password") do |v|
+      @auth = v.to_s
+    end
+    opts.on("-i", "--incremental", "Activate incremental mode") do |v|
+      @incremental = true
+    end
+  end.parse!
+
+  puts "Configuration".cyan
+  puts "  - Namespace: #{@namespace.blue}"
+  puts "  - Password:  #{@auth.blue}"
+  puts "  - Mode:      #{mode.blue}"
+  puts "  - Top:       #{@top.blue}"
+  puts "  - Work dir:  #{@workdir.blue}"
+  puts "  - SCF dir:   #{@scfdir.blue}"
+  puts "  - Domain:    #{domain.blue}"
+
+  FileUtils.mkdir_p(@workdir)
+end
+
+def mode
+  if @incremental
+    "incremental, keeping previous data"
+  else
+    "fresh, clearing previous data"
+  end
+end
+
+def engines
+  # Add new engines here. May also have to change the test case
+  # selection if the name of the test case in the brain tests deviates
+  # from the name of the database engine. We assume a name of the form
+  # `<nnn>_minibroker_<engine>_test`.
+  [
+    'mariadb',
+    'mongodb',
+    'postgresql',
+    'redis'
+  ]
+end

--- a/assessor/lib/helmrepo.rb
+++ b/assessor/lib/helmrepo.rb
@@ -6,13 +6,13 @@ def helm_repo_shutdown
     run "cf", "delete-space", "-f", "mb-charting"
     run "cf", "delete-org",   "-f", "mb-charting"
   end
-  FileUtils.remove_dir(appdir, force = true)
+  FileUtils.remove_dir(appdir, force: true)
 end
 
-def helm_repo_setup(chart, engine, chartlocation)
+def helm_repo_setup(chart, engine, chart_location)
   # Assemble and run node-env app serving the helm repository.
   # I. Copy original app into fresh directory
-  FileUtils.remove_dir(appdir, force = true)
+  FileUtils.remove_dir(appdir, force: true)
   FileUtils.cp_r(appsrc, appdir)
 
   # II. Change app name to something more suitable
@@ -21,7 +21,7 @@ def helm_repo_setup(chart, engine, chartlocation)
   File.write(manifest, m.to_yaml)
 
   # III. Write remote helm chart to local file
-  get_engine_chart(chartlocation)
+  get_engine_chart(chart_location)
 
   # IV. Patch local chart archive. Stop on failure
   return "" unless sucessfully_patched_chart(engine)
@@ -39,7 +39,6 @@ def helm_repo_setup(chart, engine, chartlocation)
   run "cf target    -o mb-charting"
   run "cf create-space mb-charting"
   run "cf target    -o mb-charting"
-  run "cf enable-feature-flag diego_docker"
 
   FileUtils.cd(appdir) do
     run "cf", "push", "-n", helm_app
@@ -49,8 +48,8 @@ def helm_repo_setup(chart, engine, chartlocation)
   helm_repo
 end
 
-def get_engine_chart(chartlocation)
-    uri = URI.parse (chartlocation)
+def get_engine_chart(chart_location)
+    uri = URI.parse (chart_location)
     res = Net::HTTP.get_response uri
     File.write(archive_orig, res.body)
 end
@@ -61,7 +60,7 @@ def sucessfully_patched_chart(engine)
     # Patch required - setup, unpack, modify, repack, cleanup
     # setup
     tmp = File.join(@workdir, "tmp")
-    FileUtils.remove_dir(tmp, force = true)
+    FileUtils.remove_dir(tmp, force: true)
     FileUtils.mkdir_p(tmp)
 
     # unpack

--- a/assessor/lib/helmrepo.rb
+++ b/assessor/lib/helmrepo.rb
@@ -40,9 +40,7 @@ def helm_repo_setup(chart, engine, chart_location)
   run "cf create-space mb-charting"
   run "cf target    -o mb-charting"
 
-  FileUtils.cd(appdir) do
-    run "cf", "push", "-n", helm_app
-  end
+  run "cf", "push", helm_app, "-p", appdir, "-n", helm_app
 
   # Report location
   helm_repo

--- a/assessor/lib/helmrepo.rb
+++ b/assessor/lib/helmrepo.rb
@@ -1,0 +1,107 @@
+
+def helm_repo_shutdown
+  # After a test we shut the local helm repository down again. We ignore failures.
+  set errexit: false do
+    run "cf", "delete",       "-f", helm_app
+    run "cf", "delete-space", "-f", "mb-charting"
+    run "cf", "delete-org",   "-f", "mb-charting"
+  end
+  FileUtils.remove_dir(appdir, force = true)
+end
+
+def helm_repo_setup(chart, engine, chartlocation)
+  # Assemble and run node-env app serving the helm repository.
+  # I. Copy original app into fresh directory
+  FileUtils.remove_dir(appdir, force = true)
+  FileUtils.cp_r(appsrc, appdir)
+
+  # II. Change app name to something more suitable
+  m = YAML.load_file (manifest)
+  m['applications'][0]['name'] = helm_app
+  File.write(manifest, m.to_yaml)
+
+  # III. Write remote helm chart to local file
+  get_engine_chart(chartlocation)
+
+  # IV. Patch local chart archive. Stop on failure
+  return "" unless sucessfully_patched_chart(engine)
+
+  # V. Place index (*) and patched chart.
+  #    (*) With proper chart archive reference
+  File.write(chart_index, make_index_yaml(chart, engine, chart_ref))
+  FileUtils.cp(archive_patched, archive_app)
+
+  # VI. Start repository (push app)
+
+  run "cf", "api", "--skip-ssl-validation", target
+  run "cf", "auth", "admin", @auth
+  run "cf create-org   mb-charting"
+  run "cf target    -o mb-charting"
+  run "cf create-space mb-charting"
+  run "cf target    -o mb-charting"
+  run "cf enable-feature-flag diego_docker"
+
+  FileUtils.cd(appdir) do
+    run "cf", "push", "-n", helm_app
+  end
+
+  # Report location
+  helm_repo
+end
+
+def get_engine_chart(chartlocation)
+    uri = URI.parse (chartlocation)
+    res = Net::HTTP.get_response uri
+    File.write(archive_orig, res.body)
+end
+
+def sucessfully_patched_chart(engine)
+  patch = patch_of(engine)
+  if File.exists?(patch)
+    # Patch required - setup, unpack, modify, repack, cleanup
+    # setup
+    tmp = File.join(@workdir, "tmp")
+    FileUtils.remove_dir(tmp, force = true)
+    FileUtils.mkdir_p(tmp)
+
+    # unpack
+    run "tar", "xfz", archive_orig, "-C", tmp
+
+    # modify
+    FileUtils.cd (File.join(tmp, engine, "templates")) do
+      @patch_stdout, _, @patch_status = capture "patch", "--verbose", "-i", patch
+    end
+    unless @patch_status.success?
+      # Check for `Reversed` and accept that, else fail
+      unless @patch_stdout =~ /Reversed/
+        return false
+      end
+    end
+
+    # repack
+    run "tar", "cfz", archive_patched, "-C", tmp, engine
+
+    # cleanup
+    FileUtils.remove_dir(tmp)
+  else
+    # No patch, just copy, cannot fail
+    FileUtils.cp(archive_orig, archive_patched)
+  end
+  true
+end
+
+def make_index_yaml (chart, engine, newloc)
+  index = {
+    'apiVersion' => 'v1',
+    'entries'    => {
+      engine => []
+    },
+  }
+  index['entries'][engine] << chart.dup
+  # Relocate
+  index['entries'][engine][0]['urls'] = [ newloc ]
+  # Go does not parse the timestamp format emitted by ruby.
+  # See if using a string is ok.
+  index['entries'][engine][0]['created'] = fixed_time
+  index.to_yaml
+end

--- a/assessor/lib/locations.rb
+++ b/assessor/lib/locations.rb
@@ -43,19 +43,19 @@ def appdir
 end
 
 def working_saved
-  @wsaved ||= File.join(archive_saved, 'index.yaml')
+  @working_saved ||= File.join(archive_saved, 'index.yaml')
 end
 
 def archive_saved
-  @asaved ||= File.join(@workdir, 'ok')
+  @archive_saved ||= File.join(@workdir, 'ok')
 end
 
 def archive_orig
-  @aunpatched ||= File.join(@workdir, 'archive-orig.tgz')
+  @archive_orig ||= File.join(@workdir, 'archive-orig.tgz')
 end
 
 def archive_patched
-  @apatched ||= File.join(@workdir, 'archive-patched.tgz')
+  @archive_patched ||= File.join(@workdir, 'archive-patched.tgz')
 end
 
 def manifest
@@ -63,11 +63,11 @@ def manifest
 end
 
 def chart_index
-  @chartindex ||= File.join(appdir, "index.yaml")
+  @chart_index ||= File.join(appdir, "index.yaml")
 end
 
 def archive_app
-  @aapp ||= File.join(appdir, chart_in_app)
+  @archive_app ||= File.join(appdir, chart_in_app)
 end
 
 def domain
@@ -79,7 +79,7 @@ def domain
 end
 
 def tester
-  @brain ||= File.join(@scfdir, "make/tests")
+  @tester ||= File.join(@scfdir, "make/tests")
 end
 
 def appsrc
@@ -87,7 +87,7 @@ def appsrc
 end
 
 def helm_repo
-  @helmrepo ||= "http://#{helm_app}.#{domain}"
+  @helm_repo ||= "http://#{helm_app}.#{domain}"
 end
 
 def target
@@ -95,5 +95,5 @@ def target
 end
 
 def chart_ref
-  @chartref ||= "#{helm_repo}/#{chart_in_app}"
+  @chart_ref ||= "#{helm_repo}/#{chart_in_app}"
 end

--- a/assessor/lib/locations.rb
+++ b/assessor/lib/locations.rb
@@ -71,7 +71,10 @@ def archive_app
 end
 
 def domain
-  @domain, _, _ = capture "kubectl get pods -o json --namespace \"#{@namespace}\" api-group-0 | jq -r '.spec.containers[0].env[] | select(.name == \"DOMAIN\").value'" unless @domain
+  unless @domain
+    pod, _, _ = capture "kubectl", "get", "pods", "-o", "yaml", "--namespace", @namespace, "api-group-0"
+    @domain = YAML.load(pod)['spec']['containers'][0]['env'].select { |ev| ev['name'] == "DOMAIN" }.first['value']
+  end
   @domain
 end
 

--- a/assessor/lib/locations.rb
+++ b/assessor/lib/locations.rb
@@ -1,0 +1,96 @@
+
+# ......................................................................
+# Engine-specific constructed values
+
+def testcase_of(engine)
+  return "_minibroker_postgres" if engine =~ /postgresql/
+  "_minibroker_#{engine}"
+end
+
+def patch_of(engine)
+  File.join(@top, "assessor/patches", "#{engine}.patch")
+end
+
+# ......................................................................
+# Various (semi)constant values, mostly paths and the like
+
+def mbbt_repository
+  "https://minibroker-helm-charts.s3.amazonaws.com/kubernetes-charts"
+end
+
+def fixed_time
+  "2018-07-30T17:55:01.330815339Z"
+end
+
+def stable
+  "https://kubernetes-charts.storage.googleapis.com"
+end
+
+def helm_app
+  "chart-under-test"
+end
+
+def chart_in_app
+  "chart.tgz"
+end
+
+def statepath
+  @statepath ||= File.join(@workdir, 'results.yaml')
+end
+
+def appdir
+  @appdir ||= File.join(@workdir, "charts")
+end
+
+def working_saved
+  @wsaved ||= File.join(archive_saved, 'index.yaml')
+end
+
+def archive_saved
+  @asaved ||= File.join(@workdir, 'ok')
+end
+
+def archive_orig
+  @aunpatched ||= File.join(@workdir, 'archive-orig.tgz')
+end
+
+def archive_patched
+  @apatched ||= File.join(@workdir, 'archive-patched.tgz')
+end
+
+def manifest
+  @manifest ||= File.join(appdir, "manifest.yml")
+end
+
+def chart_index
+  @chartindex ||= File.join(appdir, "index.yaml")
+end
+
+def archive_app
+  @aapp ||= File.join(appdir, chart_in_app)
+end
+
+def domain
+  @domain, _, _ = capture "kubectl get pods -o json --namespace \"#{@namespace}\" api-group-0 | jq -r '.spec.containers[0].env[] | select(.name == \"DOMAIN\").value'" unless @domain
+  @domain
+end
+
+def tester
+  @brain ||= File.join(@scfdir, "make/tests")
+end
+
+def appsrc
+  @appsrc ||= File.join(@scfdir, "src/scf-release/src/acceptance-tests-brain/test-resources/node-env")
+end
+
+def helm_repo
+  @helmrepo ||= "http://#{helm_app}.#{domain}"
+end
+
+def target
+  @target ||= "https://api.#{domain}"
+end
+
+def chart_ref
+  @chartref ||= "#{helm_repo}/#{chart_in_app}"
+end

--- a/assessor/lib/log.rb
+++ b/assessor/lib/log.rb
@@ -12,7 +12,8 @@ end
 def log_start(engine, enginev, chartv)
   enginedir = File.join(@workdir, engine)
   FileUtils.mkdir_p(enginedir)
-  @log = File.open(File.join(enginedir, "#{enginev}-#{chartv}.log"),
+  @logfile = File.join(enginedir, "#{enginev}-#{chartv}.log")
+  @log = File.open(@logfile,
                    File::CREAT|File::TRUNC|File::WRONLY|File::APPEND)
   log "Tracking operation ..."
 end

--- a/assessor/lib/log.rb
+++ b/assessor/lib/log.rb
@@ -1,0 +1,28 @@
+
+def separator(text)
+  sepline = '_' * 60 + " #{text} ___"
+  log "\n#{sepline.magenta}\n"
+  write text
+  message = yield
+  left text.length
+  eeol
+  write message
+end
+
+def log_start(engine, enginev, chartv)
+  enginedir = File.join(@workdir, engine)
+  FileUtils.mkdir_p(enginedir)
+  @log = File.open(File.join(enginedir, "#{enginev}-#{chartv}.log"),
+                   File::CREAT|File::TRUNC|File::WRONLY|File::APPEND)
+  log "Tracking operation ..."
+end
+
+def log(text)
+  return "" unless @log
+  @log.puts text
+  @log.flush
+end
+
+def log_done
+  @log = nil
+end

--- a/assessor/lib/spawn.rb
+++ b/assessor/lib/spawn.rb
@@ -1,0 +1,51 @@
+
+# Global option for error handling in run, capture
+$opts = { errexit: true }
+
+# ......................................................................
+# Logging, and terminal cursor control
+# First three commands snarfed from test utils and modified to suit
+# (divert output into log file)
+
+# Set global options.
+# If a block is given, the options are only active in that block.
+def set(opts={})
+    if block_given?
+        old_opts = $opts.dup
+        $opts.merge! opts
+        yield
+        $opts.merge! old_opts
+    else
+        $opts.merge! opts
+    end
+end
+
+def run(*args)
+  opts = $opts.dup
+  opts.merge! args.last if args.last.is_a? Hash
+  _, _, status = capture(*args)
+  return unless opts[:errexit]
+  unless status.success?
+    # Print an error at the failure site
+    puts "Command exited with #{status.exitstatus}".red
+    fail "Command exited with #{status.exitstatus}"
+  end
+end
+
+def capture(*args)
+  _print_command(*args)
+  args.last.delete :errexit if args.last.is_a? Hash
+  stdout, stderr, status = Open3.capture3(*args)
+  log stdout
+  log stderr.red
+  return stdout.chomp, stderr.chomp, status
+end
+
+# Internal helper: print a command line in the log.
+def _print_command(*args)
+    cmd = args.dup
+    cmd.shift if cmd.first.is_a? Hash
+    cmd.pop if cmd.last.is_a? Hash
+    log "+ #{cmd.join(" ")}".bold
+    log "\n"
+end

--- a/assessor/lib/state.rb
+++ b/assessor/lib/state.rb
@@ -15,14 +15,13 @@ def state
     #
     # version is chart version  (`version`)
     # app     is engine version (`appVersion`)
-    @state.default_proc = proc { |h, k| h[k] = Hash.new }
+    @state.default_proc = proc { |h, k| h[k] = Hash.new { |hh, kk| hh[kk] = Hash.new } }
   end
   @state
 end
 
 def state_save(engine, enginev, chartv, success)
-  @state[engine] ||= {}
-  @state[engine][chartv] = {
+  state[engine][chartv] = {
     'app'   => enginev,
     'works' => success,
   }
@@ -44,7 +43,7 @@ def regenerate_working_index
     working[engine] = []
     master_index[engine].each do |chart|
       chartv = chart['version']
-      next unless @state && @state[engine] && @state[engine][chartv] && @state[engine][chartv]['works']
+      next unless state[engine][chartv] && state[engine][chartv]['works']
       new = chart.dup
       new['created'] = fixed_time
       new['urls'] = "#{mbbt_repository}/#{engine}-#{chartv}.tgz"

--- a/assessor/lib/state.rb
+++ b/assessor/lib/state.rb
@@ -1,0 +1,55 @@
+
+def state
+  # Memoized
+  unless @state
+    # Look for state only in incremental mode. Do not fail if missing,
+    # just fall back to regular mode, starting with empty state.
+    if @incremental && File.exists?(statepath)
+      @state = YAML.load_file(statepath)
+    else
+      @state = {}
+    end
+    # Schema:
+    # - state[<engine>][<version>]['works']	:: boolean
+    # - state[<engine>][<version>]['app']	:: string
+    #
+    # version is chart version  (`version`)
+    # app     is engine version (`appVersion`)
+    @state.default_proc = proc { |h, k| h[k] = Hash.new }
+  end
+  @state
+end
+
+def state_save(engine, enginev, chartv, success)
+  @state[engine] ||= {}
+  @state[engine][chartv] = {
+    'app'   => enginev,
+    'works' => success,
+  }
+  File.write(statepath, @state.to_yaml)
+end
+
+def archive_save(engine, chartv)
+  dst = File.join(archive_saved, "#{engine}-#{chartv}.tgz")
+  FileUtils.mkdir_p(archive_saved)
+  FileUtils.cp(archive_patched, dst)
+end
+
+def regenerate_working_index
+  # Extract the chart blocks for all working charts from the master,
+  # patch the archive location to refer to the internal dev helm
+  # repository used by the brain tests, and save to a file.
+  working = {}
+  engines.each do |engine|
+    working[engine] = []
+    master_index[engine].each do |chart|
+      chartv = chart['version']
+      next unless @state && @state[engine] && @state[engine][chartv] && @state[engine][chartv]['works']
+      new = chart.dup
+      new['created'] = fixed_time
+      new['urls'] = "#{mbbt_repository}/#{engine}-#{chartv}.tgz"
+      working[engine] << new
+    end
+  end
+  File.write(working_saved, working.to_yaml)
+end

--- a/assessor/lib/terminal.rb
+++ b/assessor/lib/terminal.rb
@@ -15,7 +15,7 @@ def eeol
 end
 
 # Move to beginning of line and erase
-def rewind
+def rewind_line
   print "\r"
   eeol
 end

--- a/assessor/lib/terminal.rb
+++ b/assessor/lib/terminal.rb
@@ -1,0 +1,21 @@
+
+def write(text)
+  print text
+  $stdout.flush
+end
+
+# Move cursor n character towards the beginning of the line
+def left(n=1)
+  print "\033[#{n}D"
+end
+
+# Erase (from cursor to) End Of Line
+def eeol
+  print "\033[K"
+end
+
+# Move to beginning of line and erase
+def rewind
+  print "\r"
+  eeol
+end

--- a/assessor/lib/testcore.rb
+++ b/assessor/lib/testcore.rb
@@ -1,0 +1,26 @@
+
+def test_clear(engine)
+  set errexit: false do
+    run "cf marketplace"
+    stdout, _, _ = capture "cf service-brokers"
+    matches = stdout.match(/(minibroker-\S*)/)
+    if matches
+      broker = matches[1]
+      run "cf", "purge-service-offering", "-f", engine
+      run "cf", "delete-service-broker",  "-f", broker
+    end
+  end
+end
+
+def do_test(the_repo, engine)
+  # make/tests has to be run from the scf top directory or inside, to
+  # be able to find its include files. Running from anywhere else and
+  # GIT_ROOT is not computed correctly.
+  FileUtils.cd(@scfdir) do
+    _, _, @teststatus = capture tester, "acceptance-tests-brain",
+	                        "env.INCLUDE=#{testcase_of(engine)}",
+	                        "env.KUBERNETES_REPO=#{the_repo}",
+	                        "env.VERBOSE=true"
+  end
+  @teststatus.success?
+end

--- a/assessor/lib/testcore.rb
+++ b/assessor/lib/testcore.rb
@@ -2,9 +2,9 @@
 def test_clear(engine)
   set errexit: false do
     run "cf marketplace"
-    stdout, _, _ = capture "cf service-brokers"
+    stdout, _, status = capture "cf service-brokers"
     matches = stdout.match(/(minibroker-\S*)/)
-    if matches
+    if status.success? && matches
       broker = matches[1]
       run "cf", "purge-service-offering", "-f", engine
       run "cf", "delete-service-broker",  "-f", broker

--- a/assessor/patches/README.md
+++ b/assessor/patches/README.md
@@ -1,0 +1,9 @@
+# Patches
+
+This directory holds the database chart patches needed to make these
+databases work with minibroker.
+
+For each database `DB` the associated patch file is `<DB>.patch`.
+
+If there is no patch file for a specific `DB` then that database does
+not require patching and can be used as is.

--- a/assessor/patches/README.md
+++ b/assessor/patches/README.md
@@ -3,7 +3,7 @@
 This directory holds the database chart patches needed to make these
 databases work with minibroker.
 
-For each database `DB` the associated patch file is `<DB>.patch`.
+For each database `<DB>` the associated patch file is `<DB>.patch`.
 
-If there is no patch file for a specific `DB` then that database does
-not require patching and can be used as is.
+If there is no patch file for a specific `<DB>` then that database
+does not require patching and can be used as is.

--- a/assessor/patches/mariadb.patch
+++ b/assessor/patches/mariadb.patch
@@ -1,0 +1,42 @@
+--- master-statefulset.yaml	1969-12-31 16:00:00.000000000 -0800
++++ master-statefulset.yaml	1969-12-31 16:00:00.000000000 -0800
+@@ -50,6 +50,18 @@
+         - name: {{ . }}
+       {{- end}}
+       {{- end }}
++      {{- if .Values.master.persistence.enabled }}
++      initContainers:
++      - name: init-{{ template "mariadb.fullname" . }}
++        image: "{{ template "mariadb.image" . }}"
++        command: ["sh", "-c", "chown 1001 /bitnami/mariadb"]
++        securityContext:
++          fsGroup: 0
++          runAsUser: 0
++        volumeMounts:
++        - name: data
++          mountPath: /bitnami/mariadb
++      {{- end }}
+       containers:
+       - name: "mariadb"
+         image: {{ template "mariadb.image" . }}
+--- slave-statefulset.yaml	1969-12-31 16:00:00.000000000 -0800
++++ slave-statefulset.yaml	1969-12-31 16:00:00.000000000 -0800
+@@ -51,6 +51,18 @@
+         - name: {{ . }}
+       {{- end}}
+       {{- end }}
++      {{- if .Values.slave.persistence.enabled }}
++      initContainers:
++      - name: init-{{ template "mariadb.fullname" . }}
++        image: "{{ template "mariadb.image" . }}"
++        command: ["sh", "-c", "chown 1001 /bitnami/mariadb"]
++        securityContext:
++          fsGroup: 0
++          runAsUser: 0
++        volumeMounts:
++        - name: data
++          mountPath: /bitnami/mariadb
++      {{- end }}
+       containers:
+       - name: "mariadb"
+         image: {{ template "mariadb.image" . }}

--- a/assessor/patches/mongodb.patch
+++ b/assessor/patches/mongodb.patch
@@ -1,0 +1,21 @@
+--- deployment-standalone.yaml	1969-12-31 16:00:00.000000000 -0800
++++ deployment-standalone.yaml	1969-12-31 16:00:00.000000000 -0800
+@@ -58,6 +58,18 @@
+         - name: {{ . }}
+       {{- end}}
+       {{- end }}
++      {{- if .Values.persistence.enabled }}
++      initContainers:
++      - name: init-{{ template "mongodb.fullname" . }}
++        image: "{{ template "mongodb.image" . }}"
++        command: ["sh", "-c", "chown 1001 /bitnami/mongodb"]
++        securityContext:
++          fsGroup: 0
++          runAsUser: 0
++        volumeMounts:
++        - name: data
++          mountPath: /bitnami/mongodb
++      {{- end }}
+       containers:
+       - name: {{ template "mongodb.fullname" . }}
+         image: {{ template "mongodb.image" . }}

--- a/assessor/patches/redis.patch
+++ b/assessor/patches/redis.patch
@@ -1,0 +1,22 @@
+--- redis-master-statefulset.yaml	1969-12-31 16:00:00.000000000 -0800
++++ redis-master-statefulset.yaml	1969-12-31 16:00:00.000000000 -0800
+@@ -55,6 +55,19 @@
+       {{- if .Values.master.schedulerName }}
+       schedulerName: "{{ .Values.master.schedulerName }}"
+       {{- end }}
++      {{- if .Values.master.persistence.enabled }}
++      initContainers:
++      - name: init-{{ template "redis.fullname" . }}
++        image: "{{ template "redis.image" . }}"
++        command: ["sh", "-c", "chmod 0777 {{ .Values.master.persistence.path }}/{{ .Values.master.persistence.subPath }}"]
++        securityContext:
++          fsGroup: 0
++          runAsUser: 0
++        volumeMounts:
++        - name: redis-data
++          mountPath: {{ .Values.master.persistence.path }}
++          subPath: {{ .Values.master.persistence.subPath }}
++      {{- end }}
+       containers:
+       - name: {{ template "redis.fullname" . }}
+         image: "{{ template "redis.image" . }}"


### PR DESCRIPTION
Modified to handle the changed directory hierarchy.

## Description

https://jira.suse.com/browse/CAP-566

Script `assess-minibroker-charts.rb` to perform assessment based on current state of master index of all stable helm chart.

Patch files required by charts to work with CAP/minibroker.

Documentation (Requisites, usage).

## Test plan

  - Create CAP cluster, point `kubectl` at it.
  - Run script as per its documentation. 
  - Wait two days (for completion), or just long enough to see a single working chart.
  - Generate yaml from main results, using the secondary script, as per its documentation.
  - :warning: The referenced ticket has a `results.yml` attached, my results. This enables testing in/of incremental mode as well, which is much faster. Just removing specific entries in the file can be used to trigger testing of known (non-)working charts.

:warning: At this point the tooling is not integrated into any type of pipeline.

See https://jira.suse.com/browse/CAP-600 for the relevant ticket and work.
