### PR TITLE
accessor: fix skip_chart? check

### DIFF
--- a/assessor/bin/assess-minibroker-charts.rb
+++ b/assessor/bin/assess-minibroker-charts.rb
@@ -93,7 +93,8 @@ def base_statistics
 end
 
 def skip_chart?(engine, enginev, chartv)
-  return false unless @incremental && state[engine][chartv]
+  return false unless @incremental
+  return false if state[engine][chartv].empty?
   @skipped += 1
   rewind_line
   write "Skipping #{engine} #{enginev} #{chartv}"


### PR DESCRIPTION
Since we have defaults now, only skip the chart if the state is empty, instead of the state just existing.