### PR TITLE
Added a --check mode determining if there are untested charts or not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The script requires:
   - A working `patch` command in the `PATH`. For a vagrant box this
     means that is is necessary to run `sudo zypper install patch`
     before attempting an assessment.
-  - A working `ruby`
+  - A working `ruby`.
   - Furthermore `tar`, and `gzip`.      
 
 Run the the script using
@@ -35,6 +35,7 @@ the default configuration, i.e.
 |CF namespace	|`cf`			|-n, --namespace	|
 |Admin password	|(Vagrant standard)	|-p, --password		|
 |Mode		|Full run		|-i, --incremental	|
+|		|			|-c, --check		|
 |Work directory	|(Git root)/`_work/mb-chart-assessment`	|-w, --work-dir		|
 |SCF source dir	|(No default, must be set)		|-s, --scf-dir		|
 
@@ -43,8 +44,9 @@ regardless of any previous results. Such a run takes about 2 days at
 the moment.
 
 An incremental run should be much faster. It is activated with option
-`-i`. In this mode the script ignores all charts for which it has
-results, indicating that they have been processed already.
+`-i` or `--incremental`. In this mode the script ignores all charts
+for which it has results, indicating that they have been processed
+already.
 
 This enables easy resumption of operation if the script was aborted,
 be it a bug, or the user.
@@ -62,6 +64,12 @@ Note that the testing of a single chart can take up to 10 minutes,
 although the average looks to be about 4 to 5 minutes. With about 140
 charts to test per engine on average, and four engines we are looking
 at just shy of two days for a full assessment all engines.
+
+A variant of the incremental mode is `check` mode, activated with
+option `-c` or `--check`. In this mode the tool only determines if
+there are untested charts or not. The tools reports success if there
+are untested charts, and failure if not. This mode does not require an
+SCF cluster.
 
 ## Tool internals, for the maintainer.
 

--- a/assessor/lib/config.rb
+++ b/assessor/lib/config.rb
@@ -5,6 +5,7 @@ def config
   @auth        = "changeme"
   @incremental = false
   @scfdir      = nil
+  @check       = false
 
   OptionParser.new do |opts|
     opts.banner = "Usage: assess-minibroker-charts [options]"
@@ -22,6 +23,11 @@ def config
     end
     opts.on("-i", "--incremental", "Activate incremental mode") do |v|
       @incremental = true
+      @check       = false
+    end
+    opts.on("-c", "--check", "Activate check mode, implied incremental") do |v|
+      @check       = true
+      @incremental = true
     end
   end.parse!
 
@@ -32,13 +38,16 @@ def config
   puts "  - Top:       #{@top.blue}"
   puts "  - Work dir:  #{@workdir.blue}"
   puts "  - SCF dir:   #{@scfdir.blue}"
-  puts "  - Domain:    #{domain.blue}"
+  puts "  - Domain:    #{domain.blue}" unless @check
+  puts "  - Domain:    #{"n/a, checking only".blue}" if @check
 
   FileUtils.mkdir_p(@workdir)
 end
 
 def mode
-  if @incremental
+  if @check
+    "check mode, keeping previous data, no cluster required"
+  elsif @incremental
     "incremental, keeping previous data"
   else
     "fresh, clearing previous data"

--- a/assessor/lib/state.rb
+++ b/assessor/lib/state.rb
@@ -15,7 +15,12 @@ def state
     #
     # version is chart version  (`version`)
     # app     is engine version (`appVersion`)
+
+    # Setup auto-creation of missing top and 2nd level entries
     @state.default_proc = proc { |h, k| h[k] = Hash.new { |hh, kk| hh[kk] = Hash.new } }
+
+    # Setup auto-creation of missing 2nd level entries for existing top level entries
+    @state.each { |k, v| @state[k].default_proc = proc { |hh, kk| hh[kk] = Hash.new } }
   end
   @state
 end


### PR DESCRIPTION
Ref https://jira.suse.com/browse/CAP-600

New options `-c`, `--check`. Implies `--incremental`. In check mode no kube cluster is required. It only retrieves the master index and compares against the existing results.